### PR TITLE
Add progress log option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ An embulk output plugin to egest records as json with [`jq`](https://github.com/
 - **default_timezone**: Default timezone. (string, default: `"UTC"`)
 - **default_timestamp_format**: Default timestamp format. (string, default: `"%Y-%m-%d %H:%M:%S %z"`)
 - **default_date**: Default date. (string, default: `"1970-01-01"`)
+- **progress_log_output_interval_seconds**: Progress log output interval in seconds. if set `0`, never output progress log. (string, default: `0`)
 
 ### About `transformer_jq`
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ An embulk output plugin to egest records as json with [`jq`](https://github.com/
 - **default_timezone**: Default timezone. (string, default: `"UTC"`)
 - **default_timestamp_format**: Default timestamp format. (string, default: `"%Y-%m-%d %H:%M:%S %z"`)
 - **default_date**: Default date. (string, default: `"1970-01-01"`)
-- **logging_interval**: Progress log output interval in seconds. if set `0`, never output progress log. (string, default: `0`)
+- **logging_interval**: Progress log output interval. For example, output progress for every 10 seconds if set '10s' or never output progress log if set `0s`. (string, default: `0s`)
 
 ### About `transformer_jq`
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ An embulk output plugin to egest records as json with [`jq`](https://github.com/
 - **default_timezone**: Default timezone. (string, default: `"UTC"`)
 - **default_timestamp_format**: Default timestamp format. (string, default: `"%Y-%m-%d %H:%M:%S %z"`)
 - **default_date**: Default date. (string, default: `"1970-01-01"`)
-- **progress_log_output_interval_seconds**: Progress log output interval in seconds. if set `0`, never output progress log. (string, default: `0`)
+- **logging_interval**: Progress log output interval in seconds. if set `0`, never output progress log. (string, default: `0`)
 
 ### About `transformer_jq`
 

--- a/src/main/java/org/embulk/output/http_json/HttpJsonOutputPlugin.java
+++ b/src/main/java/org/embulk/output/http_json/HttpJsonOutputPlugin.java
@@ -118,9 +118,9 @@ public class HttpJsonOutputPlugin
         @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$")
         public String getDefaultDate();
 
-        @Config("progress_log_output_interval_seconds")
+        @Config("logging_interval")
         @ConfigDefault("0")
         @PositiveOrZero
-        public int getProgressLogOutputIntervalSeconds();
+        public int getLoggingInterval();
     }
 }

--- a/src/main/java/org/embulk/output/http_json/HttpJsonOutputPlugin.java
+++ b/src/main/java/org/embulk/output/http_json/HttpJsonOutputPlugin.java
@@ -119,8 +119,7 @@ public class HttpJsonOutputPlugin
         public String getDefaultDate();
 
         @Config("logging_interval")
-        @ConfigDefault("0")
-        @PositiveOrZero
-        public int getLoggingInterval();
+        @ConfigDefault("\"0s\"")
+        public String getLoggingInterval();
     }
 }

--- a/src/main/java/org/embulk/output/http_json/HttpJsonOutputPlugin.java
+++ b/src/main/java/org/embulk/output/http_json/HttpJsonOutputPlugin.java
@@ -117,5 +117,10 @@ public class HttpJsonOutputPlugin
         @ConfigDefault("\"1970-01-01\"")
         @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$")
         public String getDefaultDate();
+
+        @Config("progress_log_output_interval_seconds")
+        @ConfigDefault("0")
+        @PositiveOrZero
+        public int getProgressLogOutputIntervalSeconds();
     }
 }

--- a/src/main/java/org/embulk/output/http_json/HttpJsonOutputPluginDelegate.java
+++ b/src/main/java/org/embulk/output/http_json/HttpJsonOutputPluginDelegate.java
@@ -48,6 +48,8 @@ public class HttpJsonOutputPluginDelegate
 
     private final ConfigMapperFactory configMapperFactory;
 
+    private static ProgressLogger progressLogger;
+
     public HttpJsonOutputPluginDelegate(ConfigMapperFactory configMapperFactory) {
         this.configMapperFactory = configMapperFactory;
     }
@@ -62,7 +64,8 @@ public class HttpJsonOutputPluginDelegate
     }
 
     private void configureTask(PluginTask task) {
-        ProgressLogger.initializeLogger(task.getLoggingInterval());
+        progressLogger = new ProgressLogger(task.getLoggingInterval());
+        progressLogger.initializeLogger();
     }
 
     private void validateJsonQuery(String name, String jqFilter) {
@@ -103,7 +106,7 @@ public class HttpJsonOutputPluginDelegate
     @Override
     public ConfigDiff egestEmbulkData(
             PluginTask task, Schema schema, int taskCount, List<TaskReport> taskReports) {
-        ProgressLogger.finish();
+        progressLogger.finish();
         taskReports.forEach(report -> logger.info(report.toString()));
         return configMapperFactory.newConfigDiff();
     }
@@ -120,8 +123,8 @@ public class HttpJsonOutputPluginDelegate
         for (int i = 0; i < list.size(); i += sliceSize) {
             long start = System.currentTimeMillis();
             R result = function.apply(list.subList(i, Integer.min(i + sliceSize, list.size())));
-            ProgressLogger.incrementRequestCount();
-            ProgressLogger.addElapsedTime(System.currentTimeMillis() - start);
+            progressLogger.incrementRequestCount();
+            progressLogger.addElapsedTime(System.currentTimeMillis() - start);
             resultBuilder.add(result);
         }
         return Collections.unmodifiableList(resultBuilder);

--- a/src/main/java/org/embulk/output/http_json/HttpJsonOutputPluginDelegate.java
+++ b/src/main/java/org/embulk/output/http_json/HttpJsonOutputPluginDelegate.java
@@ -27,7 +27,7 @@ import org.embulk.output.http_json.jaxrs.JAXRSObjectNodeResponseEntityReader;
 import org.embulk.output.http_json.jq.IllegalJQProcessingException;
 import org.embulk.output.http_json.jq.InvalidJQFilterException;
 import org.embulk.output.http_json.jq.JQ;
-import org.embulk.output.http_json.util.ProgressLogger;
+import org.embulk.output.http_json.util.GlobalProgressLogger;
 import org.embulk.output.http_json.validator.BeanValidator;
 import org.embulk.spi.DataException;
 import org.embulk.spi.Schema;
@@ -48,7 +48,7 @@ public class HttpJsonOutputPluginDelegate
 
     private final ConfigMapperFactory configMapperFactory;
 
-    private static ProgressLogger progressLogger;
+    private static GlobalProgressLogger globalProgressLogger;
 
     public HttpJsonOutputPluginDelegate(ConfigMapperFactory configMapperFactory) {
         this.configMapperFactory = configMapperFactory;
@@ -64,8 +64,8 @@ public class HttpJsonOutputPluginDelegate
     }
 
     private void configureTask(PluginTask task) {
-        progressLogger = new ProgressLogger(task.getLoggingInterval());
-        progressLogger.initializeLogger();
+        globalProgressLogger = new GlobalProgressLogger(task.getLoggingInterval());
+        globalProgressLogger.initializeLogger();
     }
 
     private void validateJsonQuery(String name, String jqFilter) {
@@ -106,7 +106,7 @@ public class HttpJsonOutputPluginDelegate
     @Override
     public ConfigDiff egestEmbulkData(
             PluginTask task, Schema schema, int taskCount, List<TaskReport> taskReports) {
-        progressLogger.finish();
+        globalProgressLogger.finish();
         taskReports.forEach(report -> logger.info(report.toString()));
         return configMapperFactory.newConfigDiff();
     }
@@ -123,8 +123,8 @@ public class HttpJsonOutputPluginDelegate
         for (int i = 0; i < list.size(); i += sliceSize) {
             long start = System.currentTimeMillis();
             R result = function.apply(list.subList(i, Integer.min(i + sliceSize, list.size())));
-            progressLogger.incrementRequestCount();
-            progressLogger.addElapsedTime(System.currentTimeMillis() - start);
+            globalProgressLogger.incrementRequestCount();
+            globalProgressLogger.addElapsedTime(System.currentTimeMillis() - start);
             resultBuilder.add(result);
         }
         return Collections.unmodifiableList(resultBuilder);

--- a/src/main/java/org/embulk/output/http_json/HttpJsonOutputPluginDelegate.java
+++ b/src/main/java/org/embulk/output/http_json/HttpJsonOutputPluginDelegate.java
@@ -58,7 +58,7 @@ public class HttpJsonOutputPluginDelegate
         validateJsonQuery("transformer_jq", task.getTransformerJq());
         validateJsonQuery("retryable_condition_jq", task.getRetryableConditionJq());
         validateJsonQuery("success_condition_jq", task.getSuccessConditionJq());
-        ProgressLogger.setSchedule(task.getProgressLogOutputIntervalSeconds());
+        ProgressLogger.setSchedule(task.getLoggingInterval());
     }
 
     private void validateJsonQuery(String name, String jqFilter) {

--- a/src/main/java/org/embulk/output/http_json/HttpJsonOutputPluginDelegate.java
+++ b/src/main/java/org/embulk/output/http_json/HttpJsonOutputPluginDelegate.java
@@ -27,7 +27,7 @@ import org.embulk.output.http_json.jaxrs.JAXRSObjectNodeResponseEntityReader;
 import org.embulk.output.http_json.jq.IllegalJQProcessingException;
 import org.embulk.output.http_json.jq.InvalidJQFilterException;
 import org.embulk.output.http_json.jq.JQ;
-import org.embulk.output.http_json.util.GlobalProgressLogger;
+import org.embulk.output.http_json.util.ProgressLogger;
 import org.embulk.output.http_json.validator.BeanValidator;
 import org.embulk.spi.DataException;
 import org.embulk.spi.Schema;
@@ -48,7 +48,7 @@ public class HttpJsonOutputPluginDelegate
 
     private final ConfigMapperFactory configMapperFactory;
 
-    private static GlobalProgressLogger globalProgressLogger;
+    private static ProgressLogger progressLogger;
 
     public HttpJsonOutputPluginDelegate(ConfigMapperFactory configMapperFactory) {
         this.configMapperFactory = configMapperFactory;
@@ -64,8 +64,8 @@ public class HttpJsonOutputPluginDelegate
     }
 
     private void configureTask(PluginTask task) {
-        globalProgressLogger = new GlobalProgressLogger(task.getLoggingInterval());
-        globalProgressLogger.initializeLogger();
+        progressLogger = new ProgressLogger(task.getLoggingInterval());
+        progressLogger.initializeLogger();
     }
 
     private void validateJsonQuery(String name, String jqFilter) {
@@ -106,7 +106,7 @@ public class HttpJsonOutputPluginDelegate
     @Override
     public ConfigDiff egestEmbulkData(
             PluginTask task, Schema schema, int taskCount, List<TaskReport> taskReports) {
-        globalProgressLogger.finish();
+        progressLogger.finish();
         taskReports.forEach(report -> logger.info(report.toString()));
         return configMapperFactory.newConfigDiff();
     }
@@ -123,8 +123,8 @@ public class HttpJsonOutputPluginDelegate
         for (int i = 0; i < list.size(); i += sliceSize) {
             long start = System.currentTimeMillis();
             R result = function.apply(list.subList(i, Integer.min(i + sliceSize, list.size())));
-            globalProgressLogger.incrementRequestCount();
-            globalProgressLogger.addElapsedTime(System.currentTimeMillis() - start);
+            progressLogger.incrementRequestCount();
+            progressLogger.addElapsedTime(System.currentTimeMillis() - start);
             resultBuilder.add(result);
         }
         return Collections.unmodifiableList(resultBuilder);

--- a/src/main/java/org/embulk/output/http_json/HttpJsonOutputPluginDelegate.java
+++ b/src/main/java/org/embulk/output/http_json/HttpJsonOutputPluginDelegate.java
@@ -58,7 +58,7 @@ public class HttpJsonOutputPluginDelegate
         validateJsonQuery("transformer_jq", task.getTransformerJq());
         validateJsonQuery("retryable_condition_jq", task.getRetryableConditionJq());
         validateJsonQuery("success_condition_jq", task.getSuccessConditionJq());
-        ProgressLogger.setSchedule(task.getLoggingInterval());
+        ProgressLogger.initializeLogger(task.getLoggingInterval());
     }
 
     private void validateJsonQuery(String name, String jqFilter) {

--- a/src/main/java/org/embulk/output/http_json/HttpJsonOutputPluginDelegate.java
+++ b/src/main/java/org/embulk/output/http_json/HttpJsonOutputPluginDelegate.java
@@ -27,6 +27,7 @@ import org.embulk.output.http_json.jaxrs.JAXRSObjectNodeResponseEntityReader;
 import org.embulk.output.http_json.jq.IllegalJQProcessingException;
 import org.embulk.output.http_json.jq.InvalidJQFilterException;
 import org.embulk.output.http_json.jq.JQ;
+import org.embulk.output.http_json.util.Durations;
 import org.embulk.output.http_json.util.ProgressLogger;
 import org.embulk.output.http_json.validator.BeanValidator;
 import org.embulk.spi.DataException;
@@ -64,7 +65,7 @@ public class HttpJsonOutputPluginDelegate
     }
 
     private void configureTask(PluginTask task) {
-        progressLogger = new ProgressLogger(task.getLoggingInterval());
+        progressLogger = new ProgressLogger(Durations.parseDuration(task.getLoggingInterval()));
     }
 
     private void validateJsonQuery(String name, String jqFilter) {

--- a/src/main/java/org/embulk/output/http_json/HttpJsonOutputPluginDelegate.java
+++ b/src/main/java/org/embulk/output/http_json/HttpJsonOutputPluginDelegate.java
@@ -54,10 +54,14 @@ public class HttpJsonOutputPluginDelegate
 
     @Override
     public void validateOutputTask(PluginTask task, Schema embulkSchema, int taskCount) {
+        configureTask(task);
         BeanValidator.validate(task);
         validateJsonQuery("transformer_jq", task.getTransformerJq());
         validateJsonQuery("retryable_condition_jq", task.getRetryableConditionJq());
         validateJsonQuery("success_condition_jq", task.getSuccessConditionJq());
+    }
+
+    private void configureTask(PluginTask task) {
         ProgressLogger.initializeLogger(task.getLoggingInterval());
     }
 

--- a/src/main/java/org/embulk/output/http_json/HttpJsonOutputPluginDelegate.java
+++ b/src/main/java/org/embulk/output/http_json/HttpJsonOutputPluginDelegate.java
@@ -65,7 +65,6 @@ public class HttpJsonOutputPluginDelegate
 
     private void configureTask(PluginTask task) {
         progressLogger = new ProgressLogger(task.getLoggingInterval());
-        progressLogger.initializeLogger();
     }
 
     private void validateJsonQuery(String name, String jqFilter) {

--- a/src/main/java/org/embulk/output/http_json/util/Durations.java
+++ b/src/main/java/org/embulk/output/http_json/util/Durations.java
@@ -1,0 +1,48 @@
+package org.embulk.output.http_json.util;
+
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class Durations {
+    private static final Pattern PATTERN =
+            Pattern.compile(
+                    "\\s*(?:(?<days>\\d+)\\s*d)?\\s*(?:(?<hours>\\d+)\\s*h)?\\s*(?:(?<minutes>\\d+)\\s*m)?\\s*(?:(?<seconds>\\d+)\\s*s)?\\s*",
+                    Pattern.CASE_INSENSITIVE);
+
+    public static Duration parseDuration(CharSequence text) {
+        Matcher matcher = PATTERN.matcher(text);
+        if (!matcher.matches()) {
+            throw new DateTimeParseException("Invalid duration", text, 0);
+        }
+        String d = matcher.group("days");
+        String h = matcher.group("hours");
+        String m = matcher.group("minutes");
+        String s = matcher.group("seconds");
+        if (d == null && h == null && m == null && s == null) {
+            throw new DateTimeParseException("Invalid duration", text, 0);
+        }
+        return Duration.ofDays(d == null ? 0 : Long.parseLong(d))
+                .plusHours(h == null ? 0 : Long.parseLong(h))
+                .plusMinutes(m == null ? 0 : Long.parseLong(m))
+                .plusSeconds(s == null ? 0 : Long.parseLong(s));
+    }
+
+    public static String formatDuration(Duration duration) {
+        long d = duration.toDays();
+        long h = duration.minusDays(d).toHours();
+        long m = duration.minusDays(d).minusHours(h).toMinutes();
+        long s = duration.minusDays(d).minusHours(h).minusMinutes(m).getSeconds();
+
+        return Stream.of(
+                        d == 0 ? null : d + "d",
+                        h == 0 ? null : h + "h",
+                        m == 0 ? null : m + "m",
+                        s == 0 ? null : s + "s")
+                .filter(v -> v != null)
+                .collect(Collectors.joining(" "));
+    }
+}

--- a/src/main/java/org/embulk/output/http_json/util/GlobalProgressLogger.java
+++ b/src/main/java/org/embulk/output/http_json/util/GlobalProgressLogger.java
@@ -9,18 +9,18 @@ import jersey.repackaged.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ProgressLogger {
+public class GlobalProgressLogger {
     private static final long INITIAL_DELAY_SECONDS = 1;
     private static AtomicLong globalRequestCount = new AtomicLong(0);
     private static AtomicLong globalElapsedTime = new AtomicLong(0);
 
-    private static final Logger logger = LoggerFactory.getLogger(ProgressLogger.class);
+    private static final Logger logger = LoggerFactory.getLogger(GlobalProgressLogger.class);
 
     private static ScheduledExecutorService service;
 
     private final int loggingInterval;
 
-    public ProgressLogger(int loggingInterval) {
+    public GlobalProgressLogger(int loggingInterval) {
         this.loggingInterval = loggingInterval;
     }
 
@@ -34,7 +34,7 @@ public class ProgressLogger {
         }
         ThreadFactory factory =
                 new ThreadFactoryBuilder()
-                        .setNameFormat(ProgressLogger.class.getSimpleName())
+                        .setNameFormat(GlobalProgressLogger.class.getSimpleName())
                         .build();
         service = Executors.newSingleThreadScheduledExecutor(factory);
         service.scheduleAtFixedRate(

--- a/src/main/java/org/embulk/output/http_json/util/ProgressLogger.java
+++ b/src/main/java/org/embulk/output/http_json/util/ProgressLogger.java
@@ -20,11 +20,11 @@ public class ProgressLogger {
 
     private ProgressLogger() {}
 
-    public static void setSchedule(long delaySecond) {
+    public static void setSchedule(int loggingInterval) {
         if (service != null) {
             throw new UnsupportedOperationException("already scheduled.");
         }
-        if (delaySecond == 0) {
+        if (loggingInterval == 0) {
             return;
         }
         ThreadFactory factory =
@@ -37,7 +37,7 @@ public class ProgressLogger {
                     outputProgress();
                 },
                 INITIAL_DELAY_SECONDS,
-                delaySecond,
+                loggingInterval,
                 TimeUnit.SECONDS);
     }
 

--- a/src/main/java/org/embulk/output/http_json/util/ProgressLogger.java
+++ b/src/main/java/org/embulk/output/http_json/util/ProgressLogger.java
@@ -19,8 +19,8 @@ public class ProgressLogger {
                             .setNameFormat(ProgressLogger.class.getSimpleName())
                             .build());
 
-    private AtomicLong globalRequestCount = new AtomicLong(0);
-    private AtomicLong globalElapsedTime = new AtomicLong(0);
+    private final AtomicLong globalRequestCount = new AtomicLong(0);
+    private final AtomicLong globalElapsedTime = new AtomicLong(0);
 
     public ProgressLogger(int loggingInterval) {
         if (loggingInterval > 0) {

--- a/src/main/java/org/embulk/output/http_json/util/ProgressLogger.java
+++ b/src/main/java/org/embulk/output/http_json/util/ProgressLogger.java
@@ -1,5 +1,6 @@
 package org.embulk.output.http_json.util;
 
+import java.time.Duration;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -18,21 +19,22 @@ public class ProgressLogger {
     private final AtomicLong globalRequestCount = new AtomicLong(0);
     private final AtomicLong globalElapsedTime = new AtomicLong(0);
 
-    public ProgressLogger(int loggingInterval) {
+    public ProgressLogger(Duration loggingInterval) {
         service =
                 Executors.newSingleThreadScheduledExecutor(
                         new ThreadFactoryBuilder()
                                 .setNameFormat(ProgressLogger.class.getSimpleName())
                                 .build());
-        if (loggingInterval > 0) {
-            setSchedule(loggingInterval);
+        long loggingIntervalSecond = loggingInterval.getSeconds();
+        if (loggingIntervalSecond > 0) {
+            setSchedule(loggingIntervalSecond);
         } else {
             logger.warn("disabled progress log.");
             service.shutdown();
         }
     }
 
-    private void setSchedule(int loggingInterval) {
+    private void setSchedule(long loggingInterval) {
         service.scheduleAtFixedRate(
                 () -> outputProgress(), INITIAL_DELAY_SECONDS, loggingInterval, TimeUnit.SECONDS);
     }

--- a/src/main/java/org/embulk/output/http_json/util/ProgressLogger.java
+++ b/src/main/java/org/embulk/output/http_json/util/ProgressLogger.java
@@ -20,7 +20,7 @@ public class ProgressLogger {
 
     private ProgressLogger() {}
 
-    public static void setSchedule(int loggingInterval) {
+    public static void initializeLogger(int loggingInterval) {
         if (service != null) {
             throw new UnsupportedOperationException("already scheduled.");
         }

--- a/src/main/java/org/embulk/output/http_json/util/ProgressLogger.java
+++ b/src/main/java/org/embulk/output/http_json/util/ProgressLogger.java
@@ -1,0 +1,72 @@
+package org.embulk.output.http_json.util;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import jersey.repackaged.com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ProgressLogger {
+    private static final long INITIAL_DELAY_SECONDS = 1;
+    private static AtomicLong globalRequestCount = new AtomicLong(0);
+    private static AtomicLong globalElapsedTime = new AtomicLong(0);
+
+    private static final Logger logger = LoggerFactory.getLogger(ProgressLogger.class);
+
+    private static ScheduledExecutorService service;
+
+    private ProgressLogger() {}
+
+    public static void setSchedule(long delaySecond) {
+        if (service != null) {
+            throw new UnsupportedOperationException("already scheduled.");
+        }
+        if (delaySecond == 0) {
+            return;
+        }
+        ThreadFactory factory =
+                new ThreadFactoryBuilder()
+                        .setNameFormat(ProgressLogger.class.getSimpleName())
+                        .build();
+        service = Executors.newSingleThreadScheduledExecutor(factory);
+        service.scheduleAtFixedRate(
+                () -> {
+                    outputProgress();
+                },
+                INITIAL_DELAY_SECONDS,
+                delaySecond,
+                TimeUnit.SECONDS);
+    }
+
+    public static void finish() {
+        if (service != null) {
+            outputProgress();
+            if (!service.isShutdown()) {
+                service.shutdown();
+            }
+        }
+    }
+
+    public static void incrementRequestCount() {
+        globalRequestCount.incrementAndGet();
+    }
+
+    public static void addElapsedTime(long elapsedTIme) {
+        globalElapsedTime.addAndGet(elapsedTIme);
+    }
+
+    private static void outputProgress() {
+        long requestCount = globalRequestCount.get();
+        long elapsedTime = globalElapsedTime.get();
+        if (requestCount == 0) {
+            return;
+        }
+        logger.info(
+                "request count: {}, response time avg: {} ms",
+                requestCount,
+                elapsedTime / requestCount);
+    }
+}

--- a/src/main/java/org/embulk/output/http_json/util/ProgressLogger.java
+++ b/src/main/java/org/embulk/output/http_json/util/ProgressLogger.java
@@ -18,11 +18,15 @@ public class ProgressLogger {
 
     private static ScheduledExecutorService service;
 
-    private ProgressLogger() {}
+    private final int loggingInterval;
 
-    public static void initializeLogger(int loggingInterval) {
+    public ProgressLogger(int loggingInterval) {
+        this.loggingInterval = loggingInterval;
+    }
+
+    public void initializeLogger() {
         if (service != null) {
-            throw new UnsupportedOperationException("already scheduled.");
+            throw new UnsupportedOperationException("already initialized.");
         }
         if (loggingInterval == 0) {
             logger.warn("disabled progress log.");
@@ -42,7 +46,7 @@ public class ProgressLogger {
                 TimeUnit.SECONDS);
     }
 
-    public static void finish() {
+    public void finish() {
         if (service != null) {
             outputProgress();
             if (!service.isShutdown()) {
@@ -51,15 +55,15 @@ public class ProgressLogger {
         }
     }
 
-    public static void incrementRequestCount() {
+    public void incrementRequestCount() {
         globalRequestCount.incrementAndGet();
     }
 
-    public static void addElapsedTime(long elapsedTIme) {
+    public void addElapsedTime(long elapsedTIme) {
         globalElapsedTime.addAndGet(elapsedTIme);
     }
 
-    private static void outputProgress() {
+    private void outputProgress() {
         long requestCount = globalRequestCount.get();
         long elapsedTime = globalElapsedTime.get();
         if (requestCount == 0) {

--- a/src/main/java/org/embulk/output/http_json/util/ProgressLogger.java
+++ b/src/main/java/org/embulk/output/http_json/util/ProgressLogger.java
@@ -9,18 +9,18 @@ import jersey.repackaged.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class GlobalProgressLogger {
+public class ProgressLogger {
     private static final long INITIAL_DELAY_SECONDS = 1;
     private static AtomicLong globalRequestCount = new AtomicLong(0);
     private static AtomicLong globalElapsedTime = new AtomicLong(0);
 
-    private static final Logger logger = LoggerFactory.getLogger(GlobalProgressLogger.class);
+    private static final Logger logger = LoggerFactory.getLogger(ProgressLogger.class);
 
     private static ScheduledExecutorService service;
 
     private final int loggingInterval;
 
-    public GlobalProgressLogger(int loggingInterval) {
+    public ProgressLogger(int loggingInterval) {
         this.loggingInterval = loggingInterval;
     }
 
@@ -34,7 +34,7 @@ public class GlobalProgressLogger {
         }
         ThreadFactory factory =
                 new ThreadFactoryBuilder()
-                        .setNameFormat(GlobalProgressLogger.class.getSimpleName())
+                        .setNameFormat(ProgressLogger.class.getSimpleName())
                         .build();
         service = Executors.newSingleThreadScheduledExecutor(factory);
         service.scheduleAtFixedRate(

--- a/src/main/java/org/embulk/output/http_json/util/ProgressLogger.java
+++ b/src/main/java/org/embulk/output/http_json/util/ProgressLogger.java
@@ -25,6 +25,7 @@ public class ProgressLogger {
             throw new UnsupportedOperationException("already scheduled.");
         }
         if (loggingInterval == 0) {
+            logger.warn("disabled progress log.");
             return;
         }
         ThreadFactory factory =


### PR DESCRIPTION
こんな感じのログがでる。
```
2022-05-24 16:45:57.666 +0000 [INFO] (main): Started Embulk v0.9.26
2022-05-24 16:45:57.781 +0000 [INFO] (0001:transaction): Loaded plugin embulk/output/http_json from a load path
2022-05-24 16:45:57.968 +0000 [INFO] (0001:transaction): Loaded plugin embulk-parser-jsonl (0.2.2)
2022-05-24 16:45:57.995 +0000 [INFO] (0001:transaction): Listing local files at directory '.' filtering filename by prefix '00909'
2022-05-24 16:45:57.997 +0000 [INFO] (0001:transaction): "follow_symlinks" is set false. Note that symbolic links to directories are skipped.
2022-05-24 16:45:58.017 +0000 [INFO] (0001:transaction): Loading files [009096.jsonl, 009097.jsonl, 009099.jsonl, 009098.jsonl]
2022-05-24 16:45:58.066 +0000 [INFO] (0001:transaction): Using local thread executor with max_threads=32 / output tasks 16 = input tasks 4 * 4
2022-05-24 16:45:58.123 +0000 [INFO] (0001:transaction): HV000001: Hibernate Validator 7.0.1.Final
2022-05-24 16:45:58.323 +0000 [INFO] (0001:transaction): {done:  0 / 4, running: 0}
2022-05-24 16:46:04.311 +0000 [INFO] (ProgressLogger): request count: 20, response time avg: 1046 ms
2022-05-24 16:46:09.311 +0000 [INFO] (ProgressLogger): request count: 46, response time avg: 860 ms
2022-05-24 16:46:14.311 +0000 [INFO] (ProgressLogger): request count: 73, response time avg: 823 ms
2022-05-24 16:46:19.311 +0000 [INFO] (ProgressLogger): request count: 99, response time avg: 808 ms
2022-05-24 16:46:24.311 +0000 [INFO] (ProgressLogger): request count: 125, response time avg: 794 ms
2022-05-24 16:46:29.311 +0000 [INFO] (ProgressLogger): request count: 150, response time avg: 800 ms
2022-05-24 16:46:34.311 +0000 [INFO] (ProgressLogger): request count: 175, response time avg: 794 ms
2022-05-24 16:46:39.311 +0000 [INFO] (ProgressLogger): request count: 201, response time avg: 794 ms
2022-05-24 16:46:44.311 +0000 [INFO] (ProgressLogger): request count: 227, response time avg: 793 ms
2022-05-24 16:46:49.311 +0000 [INFO] (ProgressLogger): request count: 254, response time avg: 786 ms
2022-05-24 16:46:52.842 +0000 [INFO] (0001:transaction): {done:  3 / 4, running: 1}
2022-05-24 16:46:52.842 +0000 [INFO] (0001:transaction): {done:  3 / 4, running: 1}
2022-05-24 16:46:52.842 +0000 [INFO] (0001:transaction): {done:  3 / 4, running: 1}
2022-05-24 16:46:53.007 +0000 [INFO] (0001:transaction): {done:  4 / 4, running: 0}
2022-05-24 16:46:53.008 +0000 [INFO] (0001:transaction): request count: 272, response time avg: 779 ms
```